### PR TITLE
Fix damaged error on arm64 builds

### DIFF
--- a/.github/workflows/build-arm64.yml
+++ b/.github/workflows/build-arm64.yml
@@ -89,8 +89,8 @@ jobs:
           codesign --force --deep -s - "Xenolauncher-arm64.app"
 
           # Apply a Finder custom icon to the final .app bundle
-          # ICON_SRC="${GITHUB_WORKSPACE}/icon.png"
-          # "${GITHUB_WORKSPACE}/fileicon" set "Xenolauncher-arm64.app" "${ICON_SRC}"
+          ICON_SRC="${GITHUB_WORKSPACE}/icon.png"
+          "${GITHUB_WORKSPACE}/fileicon" set "Xenolauncher-arm64.app" "${ICON_SRC}"
 
           # Create tar.gz preserving extended attributes (Finder icon, etc.)
           tar --xattrs -czf "../Xenolauncher-arm64.tar.gz" "Xenolauncher-arm64.app"


### PR DESCRIPTION
arm64 versions of macos require ad-hoc signing